### PR TITLE
Add all files in i18n folder to npm repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,7 @@
   "homepage": "https://github.com/syncfusion/ej-global#readme",
   
   "files": [
-        "i18n/ej.culture.ar-AE.js",
-		"i18n/ej.culture.de-DE.js",
-		"i18n/ej.culture.en-US.js",
-		"i18n/ej.culture.es-ES.js",
-		"i18n/ej.culture.fr-FR.js",
-		"i18n/ej.culture.vi-VN.js",
-		"i18n/ej.culture.zh-CN.js",    
+        "i18n/",    
 		"l10n/"
     ]
 }


### PR DESCRIPTION
I belive it was unremoved stub, because in the current version of .npmignore file there is no restrictions for these files.